### PR TITLE
Remove unused imports

### DIFF
--- a/pihole6_exporter.py
+++ b/pihole6_exporter.py
@@ -7,11 +7,9 @@ import urllib3
 import logging
 import argparse
 import psutil
-from prometheus_client import Histogram, Counter
 from prometheus_client.core import GaugeMetricFamily, CounterMetricFamily, REGISTRY
 from prometheus_client.registry import Collector
 from prometheus_client import start_http_server
-import platform
 
 class PiholeCollector(Collector):
 


### PR DESCRIPTION
## Summary
- tidy pihole6_exporter imports by removing Histogram, Counter, and platform

## Testing
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_6850d2fb08848326acdce92e0eea653b