### PR TITLE
ci: build multi-arch (amd64 + arm64) Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,6 +71,7 @@ jobs:
           context: .
           file: ./Dockerfile.metrics
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta_metrics.outputs.tags }}
           labels: ${{ steps.meta_metrics.outputs.labels }}
           cache-from: type=gha
@@ -82,6 +83,7 @@ jobs:
           context: .
           file: ./Dockerfile.logs
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta_logs.outputs.tags }}
           labels: ${{ steps.meta_logs.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Summary

The CI workflow already sets up QEMU and buildx but `platforms:` is unset on both `docker/build-push-action` calls, so it defaults to the runner's native arch (`linux/amd64`). This PR adds `platforms: linux/amd64,linux/arm64` to both build steps so the published images become multi-arch manifest lists.

## Why

I'm running this exporter on an arm64 host (Lima VM on Apple Silicon, Ubuntu 24.04, Docker 29) and there's no published arm64 image to pull, so I'm building locally from source. Two extra lines in the workflow lets every arm64 user (Raspberry Pi, Apple Silicon, AWS Graviton, etc.) `docker pull` instead.

## Test plan

- [x] Verified both Dockerfiles build cleanly on arm64 (Ubuntu 24.04, Docker 29) — `requirements.txt` is pure Python with manylinux arm64 wheels for every dep, no native compilation needed.
- [ ] CI on this PR will exercise the multi-arch build on the GitHub runner (amd64 native + arm64 via QEMU). Cross-arch QEMU build typically adds ~2 min vs amd64-only.