### PR TITLE
Harden Pi-hole Loki log exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ python pihole6_metrics_exporter.py -H localhost -k YOUR_API_TOKEN -p 9090
 
 ```bash
 cd logs_exporter
-python pihole6_logs_exporter.py -H localhost -k YOUR_API_TOKEN -u http://localhost:3100/loki/api/v1/push
+python pihole6_logs_exporter.py -H http://localhost:80 -k YOUR_API_TOKEN -t http://localhost:3100 --server pihole-vm
 ```
 
 ## Installation

--- a/logs_exporter/README.md
+++ b/logs_exporter/README.md
@@ -31,20 +31,22 @@ The timer uses environment variables that can be set in `etc/pihole6_exporter/pi
 - `PIHOLE_URL` - Pi-hole server URL (default: http://localhost:80)
 - `PIHOLE_API_TOKEN` - Pi-hole API token for authentication
 - `LOKI_TARGET` - Loki server URL (e.g., http://localhost:3100/loki/api/v1/push)
-- `SERVER_NAME` - Server identifier for Loki labels (e.g., 'pihole-vm', 'tarkilnas'). Defaults to hostname if not set.
+- `SERVER_NAME` - Stable server identifier for Loki `host` and `server` labels (e.g., 'pihole-vm', 'tarkilnas'). Defaults to hostname if not set.
 - `STATE_FILE` - Path to state file for tracking last processed timestamp (default: /var/tmp/pihole_logs_exporter.state)
 
 ### Manual Execution
 
 ```bash
-python pihole6_logs_exporter.py -H localhost -k YOUR_API_TOKEN -u http://localhost:3100/loki/api/v1/push
+python pihole6_logs_exporter.py -H http://localhost:80 -k YOUR_API_TOKEN -t http://localhost:3100 --server pihole-vm
 ```
 
 ## Features
 
 - Exports Pi-hole query logs to Loki format
+- Keeps high-cardinality DNS fields (`domain`, `client_ip`, `client_name`) out of Loki stream labels and sends them as structured metadata plus JSON log fields
+- Uses a stable `SERVER_NAME` for Loki `host` / `server` labels
 - Maintains state to avoid duplicate log entries
 - Resolves client IPs to hostnames
 - Configurable initial history fetch
-- Automatic retry on failures
-- Runs every 30 seconds via systemd timer 
+- Exits non-zero on authentication, API, Loki push, or state-write failures
+- Runs every 30 seconds via systemd timer

--- a/logs_exporter/pihole6_logs_exporter.py
+++ b/logs_exporter/pihole6_logs_exporter.py
@@ -15,6 +15,7 @@ class PiholeLogsExporter:
     Exports Pi-hole query logs to a Loki-compatible endpoint (like Grafana Alloy).
     """
     CACHE_TTL = 3600
+    DEFAULT_LOOKBACK_SECONDS = 1800
 
     def __init__(self, host, key, loki_target, state_file, server_name=None):
         # Prefer environment variable if set, otherwise use provided host
@@ -23,7 +24,7 @@ class PiholeLogsExporter:
             host = env_host
         elif host is None or host == '':
             raise ValueError("PIHOLE_URL environment variable must be set, or --host argument must be provided")
-        
+
         self.host = host.rstrip('/')  # Remove trailing slash if present
         self.key = key
         self.loki_target = loki_target
@@ -33,35 +34,16 @@ class PiholeLogsExporter:
         self.using_auth = False
         self.sid = None
         self.hostname_cache = {}
-        
+
         # Disable SSL warnings for self-signed certificates
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
         logging.info(f"Initializing Pi-hole Logs Exporter with host: {host}, loki_target: {loki_target}, state_file: {state_file}")
-        
+
         if key is not None:
             self.using_auth = True
             logging.info("Authentication enabled - will attempt to get session ID")
-            try:
-                self.sid = self.get_sid(key)
-                if self.sid:
-                    logging.info(f"Session ID stored successfully: {self.sid[:20]}... (length: {len(self.sid)})")
-                else:
-                    logging.warning("Session ID is None after authentication - API may work without it or use alternative auth")
-                    # Don't disable auth flag - we still attempted authentication
-                    # The API calls will handle missing session ID gracefully
-            except (ValueError, KeyError) as e:
-                # Authentication failed - log error but don't crash
-                # API calls might still work if authentication isn't strictly required
-                logging.error(f"Authentication failed: {e}")
-                logging.warning("Continuing without authentication - API calls may fail if authentication is required")
-                self.sid = None
-                # Keep using_auth = True so we know we tried, but API calls will handle missing SID
-            except Exception as e:
-                logging.error(f"Unexpected error during authentication: {e}")
-                self.sid = None
-                self.using_auth = False
-                # Don't raise - allow the exporter to continue, API calls will handle missing auth
+            self.sid = self.get_sid(key)
         else:
             logging.warning("No API token provided. Pi-hole v6 may require authentication to access query logs. Some information may not be available.")
 
@@ -73,7 +55,7 @@ class PiholeLogsExporter:
         logging.info(f"Attempting to authenticate with Pi-hole API at {auth_url}")
         try:
             req = requests.post(auth_url, verify=False, headers=headers, json=json_data, timeout=10)
-            
+
             # Handle HTTP 401 (Unauthorized) - some Pi-hole instances return this for auth failures
             if req.status_code == 401:
                 try:
@@ -81,16 +63,15 @@ class PiholeLogsExporter:
                     session = reply.get('session', {})
                     error_msg = session.get('message', 'Authentication failed (HTTP 401)')
                     logging.error(f"Authentication failed with HTTP 401: {error_msg}")
-                    logging.error(f"Full response: {json.dumps(reply, indent=2)}")
                     raise ValueError(f"Authentication failed: {error_msg}")
                 except (json.JSONDecodeError, KeyError):
                     logging.error(f"Authentication failed with HTTP 401. Response: {req.text}")
                     raise ValueError("Authentication failed: HTTP 401 Unauthorized")
-            
+
             # For other status codes, raise if not successful
             req.raise_for_status()
             reply = req.json()
-            
+
             # Extract session ID with better error handling
             # Handle both response formats:
             # 1. HTTP 401 (already handled above)
@@ -100,53 +81,40 @@ class PiholeLogsExporter:
                 sid = session.get('sid')
                 is_valid = session.get('valid', False)
                 error_msg = session.get('message', '')
-                
+
                 # Determine if authentication failed based on multiple indicators
                 # Some instances return HTTP 200 but indicate failure in the response body
                 auth_failed = False
                 failure_reason = None
-                
+
                 # Check 1: Session marked as invalid
                 if not is_valid:
                     auth_failed = True
                     failure_reason = error_msg or 'Session is not valid'
-                
+
                 # Check 2: Session ID is null/empty AND there's an error message
                 elif not sid or not sid.strip():
-                    if error_msg:
-                        auth_failed = True
-                        failure_reason = error_msg
-                    # If no error message but sid is null, might be edge case - log warning
-                    elif not error_msg:
-                        logging.warning("Session ID is null/empty but no error message provided")
-                        logging.warning(f"Response structure: {json.dumps(reply, indent=2)}")
-                
+                    auth_failed = True
+                    failure_reason = error_msg or 'missing valid session'
+
                 # Check 3: Error message indicates failure (catch-all for any error messages)
-                elif error_msg and any(keyword in error_msg.lower() for keyword in 
+                elif error_msg and any(keyword in error_msg.lower() for keyword in
                                       ['incorrect', 'invalid', 'failed', 'error', 'unauthorized', 'denied']):
                     auth_failed = True
                     failure_reason = error_msg
-                
+
                 # If authentication failed, raise error
                 if auth_failed:
                     logging.error(f"Authentication failed: {failure_reason}")
-                    logging.error(f"Full response: {json.dumps(reply, indent=2)}")
                     raise ValueError(f"Authentication failed: {failure_reason}")
-                
+
                 # Success case: valid session with non-empty session ID
                 if sid and sid.strip():
                     logging.info("Successfully authenticated with Pi-hole API.")
                     logging.info(f"Session ID obtained: {sid[:20]}... (length: {len(sid)})")
                     return sid
-                else:
-                    # Edge case: no error indicators but also no valid session ID
-                    logging.warning("Session ID is null or empty in API response (no error detected)")
-                    logging.warning(f"Response structure: {json.dumps(reply, indent=2)}")
-                    logging.warning("Continuing without session ID - API calls may still work if authentication is not strictly required")
-                    return None
             except KeyError as e:
                 logging.error(f"Session ID not found in API response. Response keys: {list(reply.keys())}")
-                logging.error(f"Full response: {json.dumps(reply, indent=2)}")
                 # Try alternative response structures
                 if 'session' in reply:
                     logging.error(f"Session object exists but structure is different: {reply['session']}")
@@ -161,22 +129,22 @@ class PiholeLogsExporter:
         if not self.using_auth:
             logging.debug("Authentication not enabled, skipping logout.")
             return
-        
+
         if not self.sid:
             logging.warning("Session ID is None when logout called. This may indicate a problem with session management.")
             logging.warning(f"Current state: using_auth={self.using_auth}, sid={self.sid}")
             return
-        
+
         # Store session ID before clearing it
         session_id = self.sid
         logging.info(f"Logging out with session ID: {session_id[:20]}...")
         logout_url = f"{self.host}/api/auth?sid={session_id}"
         headers = {"accept": "application/json"}
-        
+
         # Clear session ID immediately to prevent double logout attempts
         self.sid = None
         self.using_auth = False
-        
+
         try:
             req = requests.delete(logout_url, verify=False, headers=headers, timeout=10)
             req.raise_for_status()
@@ -193,7 +161,7 @@ class PiholeLogsExporter:
             logging.debug(f"Using session ID for API call: {self.sid[:10]}...")
         elif self.using_auth and not self.sid:
             logging.warning("Authentication enabled but session ID is missing for API call")
-        
+
         logging.info(f"Making API call to: {url}")
         try:
             req = requests.get(url, verify=False, headers=headers, timeout=30)
@@ -214,19 +182,19 @@ class PiholeLogsExporter:
             with open(self.state_file, 'r') as f:
                 content = f.read().strip()
                 if not content:
-                    ts = int(time.time()) - 1800
-                    logging.info(f"State file {self.state_file} is empty. Starting from 1 hour ago (timestamp {ts}).")
+                    ts = int(time.time()) - self.DEFAULT_LOOKBACK_SECONDS
+                    logging.info(f"State file {self.state_file} is empty. Starting from {self.DEFAULT_LOOKBACK_SECONDS} seconds ago (timestamp {ts}).")
                     return ts
                 timestamp = int(content)
                 logging.info(f"Read last timestamp from state file: {timestamp} ({time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(timestamp))})")
                 return timestamp
         except FileNotFoundError:
-            ts = int(time.time()) - 1800
-            logging.info(f"State file not found at {self.state_file}. Starting from 1 hour ago (timestamp {ts}).")
+            ts = int(time.time()) - self.DEFAULT_LOOKBACK_SECONDS
+            logging.info(f"State file not found at {self.state_file}. Starting from {self.DEFAULT_LOOKBACK_SECONDS} seconds ago (timestamp {ts}).")
             return ts
         except (ValueError, TypeError) as e:
             logging.error(f"Invalid timestamp in state file: {e}. Starting fresh.")
-            return int(time.time()) - 1800  # Start from 30 minutes ago
+            return int(time.time()) - self.DEFAULT_LOOKBACK_SECONDS
 
     def write_last_timestamp(self, timestamp):
         """Writes the latest timestamp to the state file."""
@@ -236,6 +204,7 @@ class PiholeLogsExporter:
             logging.info(f"Wrote timestamp to state file: {timestamp} ({time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(timestamp))})")
         except IOError as e:
             logging.error(f"Error writing to state file {self.state_file}: {e}")
+            raise
 
     def resolve_hostname(self, ip):
         """Resolve an IP address to a hostname with caching. Returns only the short hostname."""
@@ -281,23 +250,16 @@ class PiholeLogsExporter:
         """Formats Pi-hole queries into Loki stream format."""
         streams = {}
         max_timestamp = 0
-        debug_logged = False
 
         logging.info(f"Formatting {len(queries)} queries for Loki")
 
         for q in queries:
-            if not debug_logged:
-                logging.info("--- DEBUG: First query structure ---")
-                logging.info(json.dumps(q, indent=2))
-                logging.info("------------------------------------")
-                debug_logged = True
-            
             # The query time from Pi-hole v6 API is in the 'time' field as a Unix timestamp.
             q_ts = q.get('time')
             if not q_ts:
                 logging.warning(f"Query missing 'time' field, skipping: {q}")
                 continue
-            
+
             q_ts = int(float(q_ts))
             max_timestamp = max(max_timestamp, q_ts)
             ts_ns = str(q_ts * 1_000_000_000)
@@ -314,7 +276,7 @@ class PiholeLogsExporter:
                 "job": "pihole_logs_exporter",
                 "service": "pihole_query_log",
                 "server": self.server_name,
-                "host": self.host,
+                "host": self.server_name,
                 "type": q.get('type', 'unknown'),
                 "status": q.get('status', 'unknown'),
             }
@@ -323,19 +285,19 @@ class PiholeLogsExporter:
                 "client_ip": str(client_ip),
                 "client_name": str(client_name),
             }
-            
+
             labels_tuple = tuple(sorted(stream_labels.items()))
-            
+
             if labels_tuple not in streams:
                 streams[labels_tuple] = {
                     "stream": stream_labels,
                     "values": []
                 }
-            
+
             flat_q = self._flatten_dict(q)
-            log_line = json.dumps(flat_q)
+            log_line = json.dumps(flat_q, separators=(",", ":"), sort_keys=True)
             streams[labels_tuple]["values"].append([ts_ns, log_line, structured_metadata])
-        
+
         logging.info(f"Formatted {len(streams)} unique streams for Loki")
         return list(streams.values()), max_timestamp
 
@@ -348,11 +310,11 @@ class PiholeLogsExporter:
         payload = {"streams": streams}
         headers = {"Content-Type": "application/json"}
         loki_url = self.get_loki_url()
-        
+
         logging.info(f"Sending {len(streams)} streams to Loki at {loki_url}")
         log_count = sum(len(s['values']) for s in streams)
         logging.info(f"Total log entries to send: {log_count}")
-        
+
         try:
             response = requests.post(loki_url, data=json.dumps(payload), headers=headers, timeout=15)
             response.raise_for_status()
@@ -369,15 +331,15 @@ class PiholeLogsExporter:
         # Validate that loki_target is provided and not empty
         if not self.loki_target or self.loki_target.strip() == "":
             raise ValueError("LOKI_URL environment variable is not set or is empty")
-        
+
         # Check if the target is just a path (missing scheme and hostname)
         if self.loki_target.startswith('/'):
             raise ValueError(f"LOKI_URL is just a path '{self.loki_target}'. Please provide a complete URL with scheme and hostname (e.g., http://localhost:3100)")
-        
+
         # Check if the target has a scheme
         if not self.loki_target.startswith(('http://', 'https://')):
             raise ValueError(f"LOKI_URL missing scheme '{self.loki_target}'. Please provide a complete URL with http:// or https://")
-        
+
         return f"{self.loki_target.rstrip('/')}/loki/api/v1/push"
 
     def run(self):
@@ -389,64 +351,54 @@ class PiholeLogsExporter:
                 logging.debug(f"Session ID verified at start of run: {self.sid[:20]}...")
             else:
                 logging.error("Session ID is missing at start of run! This should not happen.")
-        try:
-            # Validate Loki target before proceeding
-            try:
-                loki_url = self.get_loki_url()
-                logging.info(f"Loki target validated: {loki_url}")
-            except ValueError as e:
-                logging.error(f"Invalid Loki configuration: {e}")
-                logging.error("Please set LOKI_URL to a complete URL (e.g., http://localhost:3100) and restart the service.")
-                return
-            
-            last_ts = self.read_last_timestamp()
-            current_ts = int(time.time())
-            
-            logging.info(f"Current timestamp: {current_ts} ({time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(current_ts))})")
 
-            if last_ts >= current_ts:
-                logging.info("Last timestamp is current, no new logs to fetch.")
-                return
+        loki_url = self.get_loki_url()
+        logging.info(f"Loki target validated: {loki_url}")
 
-            queries = self.fetch_queries(last_ts, current_ts)
+        last_ts = self.read_last_timestamp()
+        current_ts = int(time.time())
 
-            if not queries:
-                self.write_last_timestamp(current_ts)
-                logging.info("No new queries found in the time range.")
-                return
-            
-            loki_streams, max_ts = self.format_for_loki(queries)
+        logging.info(f"Current timestamp: {current_ts} ({time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(current_ts))})")
 
-            if loki_streams:
-                self.send_to_loki(loki_streams)
-                self.write_last_timestamp(max_ts)
-            else:
-                # No valid queries were formatted, but we should still advance the timestamp
-                self.write_last_timestamp(current_ts)
+        if last_ts >= current_ts:
+            logging.info("Last timestamp is current, no new logs to fetch.")
+            return
 
-            logging.info("Pi-hole log export run finished.")
+        queries = self.fetch_queries(last_ts, current_ts)
 
-        except Exception as e:
-            logging.error(f"An unexpected error occurred during the run: {e}", exc_info=True)
-        # Note: logout is handled in the main script's finally block to avoid double logout
+        if not queries:
+            self.write_last_timestamp(current_ts)
+            logging.info("No new queries found in the time range.")
+            return
+
+        loki_streams, max_ts = self.format_for_loki(queries)
+
+        if loki_streams:
+            self.send_to_loki(loki_streams)
+            self.write_last_timestamp(max_ts)
+        else:
+            # No valid queries were formatted, but we should still advance the timestamp
+            self.write_last_timestamp(current_ts)
+
+        logging.info("Pi-hole log export run finished.")
 
 def setup_logging(log_level, log_file=None):
     """Setup logging with both console and file handlers."""
     # Create formatter
     formatter = logging.Formatter('time="%(asctime)s" level="%(levelname)s" message="%(message)s"')
-    
+
     # Create logger
     logger = logging.getLogger()
     logger.setLevel(getattr(logging, log_level.upper()))
-    
+
     # Clear any existing handlers
     logger.handlers.clear()
-    
+
     # Console handler
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(formatter)
     logger.addHandler(console_handler)
-    
+
     # File handler (if specified)
     if log_file:
         # Ensure log directory exists
@@ -457,10 +409,10 @@ def setup_logging(log_level, log_file=None):
                 logging.info(f"Created log directory: {log_dir}")
             except Exception as e:
                 logging.error(f"Failed to create log directory {log_dir}: {e}")
-        
+
         # Create rotating file handler
         file_handler = RotatingFileHandler(
-            log_file, 
+            log_file,
             maxBytes=5*1024*1024,  # 5MB
             backupCount=5
         )

--- a/tests/test_logs_exporter_static.py
+++ b/tests/test_logs_exporter_static.py
@@ -45,37 +45,37 @@ def mock_get_api_call(api_path):
     if not match:
         # If no parameters found, return all data
         return {"queries": STATIC_QUERIES}
-    
+
     from_ts = int(match.group(1))
     until_ts = int(match.group(2))
-    
+
     # Filter queries based on timestamp range
     filtered_queries = []
     for query in STATIC_QUERIES:
         query_time = query["time"]
         if from_ts < query_time <= until_ts:
             filtered_queries.append(query)
-    
+
     return {"queries": filtered_queries}
 
 class TestLogsExporterStatic:
     """Test logs exporter using static data."""
-    
+
     def setup_method(self):
         """Set up test fixtures."""
         # Create temporary directory for state file
         self.temp_dir = os.path.join(os.path.dirname(__file__), "temp_test_dir")
         os.makedirs(self.temp_dir, exist_ok=True)
         self.state_file = os.path.join(self.temp_dir, "test_state.txt")
-        
+
         # Mock current time to 22 JUN 2025 20:00:00 UTC
         self.mock_now = 1750622400  # 22 JUN 2025 20:00:00 UTC
-        
+
         # Get Loki target from environment variable
         loki_target = os.getenv("LOKI_TARGET")
         if not loki_target:
             pytest.skip("No LOKI_TARGET environment variable set.")
-        
+
         # Create exporter with mocked authentication
         with patch.object(PiholeLogsExporter, 'get_sid', return_value="mock-session-id"):
             self.exporter = PiholeLogsExporter(
@@ -85,78 +85,79 @@ class TestLogsExporterStatic:
                 state_file=self.state_file,
                 server_name="test-server"
             )
-    
+
     def teardown_method(self):
         """Clean up test fixtures."""
         # Remove temporary directory
         import shutil
         shutil.rmtree(self.temp_dir, ignore_errors=True)
-    
-    def test_no_state_file_starts_from_epoch(self):
-        """Test 1: No state file causes read_last_timestamp to return now-1h, fetching recent entries only."""
+
+    def test_no_state_file_starts_from_recent_lookback(self):
+        """Test 1: No state file starts from the bounded default lookback."""
         # 1. Ensure state file doesn't exist
         assert not os.path.exists(self.state_file), "State file should not exist for this test"
 
-        # 2. Call read_last_timestamp and verify it returns now-1h
+        # 2. Call read_last_timestamp and verify it returns now-lookback
         with patch('time.time', return_value=self.mock_now):
             from_ts = self.exporter.read_last_timestamp()
-            assert from_ts == self.mock_now - 3600, f"read_last_timestamp should return now-1h for a missing state file, got {from_ts}"
+            assert from_ts == self.mock_now - self.exporter.DEFAULT_LOOKBACK_SECONDS, f"read_last_timestamp should return now-lookback for a missing state file, got {from_ts}"
 
         # 3. Now, test the fetch_queries integration with this timestamp
         with patch.object(self.exporter, 'get_api_call', side_effect=mock_get_api_call):
             with patch('time.time', return_value=self.mock_now):
                 until_ts = self.mock_now
                 result = self.exporter.fetch_queries(from_ts, until_ts)
-                # We expect 51 entries because we're querying from 19:00:00 to 20:00:00 (1 hour)
-                assert len(result) == 51, f"Expected 51 queries when starting from now-1h, but got {len(result)}"
+                # We expect 51 entries because the static fixture contains 51
+                # queries in the bounded initial lookback window.
+                assert len(result) == 51, f"Expected 51 queries when starting from now-lookback, but got {len(result)}"
                 print(f"✅ Test 1 passed: No state file, read_last_timestamp returned {from_ts}, fetched {len(result)} queries.")
-    
+
     def test_fetch_queries_with_state_file_returns_correct_count(self):
         """Test 2: State file at 19:55:00 should return correct count."""
-        
+
         # Create state file with timestamp at 22 JUN 2025 19:55:00
         state_timestamp = 1750622100  # 22 JUN 2025 19:55:00 (earlier than mock_now)
         with open(self.state_file, 'w') as f:
             f.write(str(state_timestamp))
-        
+
         with patch.object(self.exporter, 'get_api_call', side_effect=mock_get_api_call):
             with patch('time.time', return_value=self.mock_now):
                 from_ts = state_timestamp
                 until_ts = self.mock_now
-                
+
                 result = self.exporter.fetch_queries(from_ts, until_ts)
-                
+
                 # Should get 25 entries between 19:55:00 and 20:00:00
                 # (5 entries per minute for 5 minutes: 19:55, 19:56, 19:57, 19:58, 19:59)
                 assert len(result) == 25, f"Expected 25 queries between 19:55:00 and 20:00:00, but got {len(result)}"
-                
+
                 print(f"✅ Test 2 passed: Retrieved {len(result)} queries (from 19:55:00 to 20:00:00)")
-    
+
     def test_write_last_timestamp_updates_state_file(self):
         """Test 3: write_last_timestamp should update state file correctly."""
-        
+
         with patch.object(self.exporter, 'get_api_call', side_effect=mock_get_api_call):
             with patch('time.time', return_value=self.mock_now):
                 from_ts = 0
                 until_ts = self.mock_now
-                
+
                 result = self.exporter.fetch_queries(from_ts, until_ts)
                 max_timestamp = max(q["time"] for q in result)
-                
+
                 self.exporter.write_last_timestamp(max_timestamp)
-                
+
                 assert os.path.exists(self.state_file)
-                
+
                 with open(self.state_file, 'r') as f:
                     written_timestamp = int(f.read().strip())
-                
+
                 assert written_timestamp == max_timestamp
-                
+
                 print(f"✅ Test 3 passed: State file updated with timestamp {written_timestamp}")
 
     def test_format_for_loki_creates_correct_structure(self):
         """Test 4: Verify that format_for_loki creates the correct Loki stream structure."""
-        
+
         # Create sample queries that match the structure from our static data
         sample_queries = [
             {
@@ -215,7 +216,7 @@ class TestLogsExporterStatic:
             "job": "pihole_logs_exporter",
             "service": "pihole_query_log",
             "server": "test-server",
-            "host": "localhost",
+            "host": "test-server",
             "type": "A",
             "status": "gravity",
         }
@@ -237,13 +238,13 @@ class TestLogsExporterStatic:
         # Verify stream for google.com
         assert stream_aaaa_forwarded is not None, "Stream for AAAA/forwarded not found"
         assert len(stream_aaaa_forwarded['values']) == 1, f"Expected 1 value for AAAA/forwarded, got {len(stream_aaaa_forwarded['values'])}"
-        
+
         # Check labels for stream_aaaa_forwarded
         expected_labels_aaaa_forwarded = {
             "job": "pihole_logs_exporter",
             "service": "pihole_query_log",
             "server": "test-server",
-            "host": "localhost",
+            "host": "test-server",
             "type": "AAAA",
             "status": "forwarded",
         }
@@ -271,17 +272,44 @@ class TestLogsExporterStatic:
 
         print(f"✅ Test 4 passed: Loki formatting creates correct structure with {len(streams)} streams and {sum(len(s['values']) for s in streams)} total entries")
 
+    def test_auth_failure_is_fatal_when_key_is_supplied(self):
+        """A configured API key should fail fast when Pi-hole rejects it."""
+        with patch.object(PiholeLogsExporter, 'get_sid', side_effect=ValueError("bad token")):
+            with pytest.raises(ValueError, match="bad token"):
+                PiholeLogsExporter(
+                    host="localhost",
+                    key="bad-key",
+                    loki_target="http://test-loki:3100",
+                    state_file=self.state_file,
+                    server_name="test-server"
+                )
+
+    def test_run_propagates_loki_push_failure(self):
+        """Failed pushes should leave systemd/cron with a non-zero process status."""
+        with patch.object(self.exporter, 'read_last_timestamp', return_value=self.mock_now - 60), \
+             patch('time.time', return_value=self.mock_now), \
+             patch.object(self.exporter, 'fetch_queries', return_value=[{
+                 "time": str(self.mock_now - 30),
+                 "client": {"ip": "192.168.1.100"},
+                 "type": "A",
+                 "status": "gravity",
+                 "domain": "example.com",
+             }]), \
+             patch.object(self.exporter, 'send_to_loki', side_effect=RuntimeError("loki down")):
+            with pytest.raises(RuntimeError, match="loki down"):
+                self.exporter.run()
+
 if __name__ == "__main__":
     # Run all tests
     test_instance = TestLogsExporterStatic()
-    
+
     print("🧪 Running Logs Exporter Static Tests...")
     print("=" * 50)
-    
+
     test_instance.setup_method()
-    
+
     try:
-        test_instance.test_no_state_file_starts_from_epoch()
+        test_instance.test_no_state_file_starts_from_recent_lookback()
         test_instance.test_fetch_queries_with_state_file_returns_correct_count()
         test_instance.test_write_last_timestamp_updates_state_file()
         test_instance.test_format_for_loki_creates_correct_structure()


### PR DESCRIPTION
## Summary

Hardens the Pi-hole v6 Loki log exporter by combining the low-cardinality structured metadata behavior with safer operational semantics for systemd/timer deployments.

Changes:
- keep DNS fields (`domain`, `client_ip`, `client_name`) out of Loki stream labels and in structured metadata / JSON log content
- use the stable `SERVER_NAME` value for both Loki `server` and `host` labels instead of using the Pi-hole API URL as `host`
- remove INFO-level logging of raw query payloads
- keep deterministic compact JSON log lines
- fail fast on authentication failures and propagate API/Loki/state-write failures so systemd can report a failed run
- document the corrected CLI flags and label behavior
- update static tests for stable host labels and failure propagation

## Why

The exporter is now the single golden source for both Docker and VM deployments. It needs to preserve the Loki low-cardinality contract while still failing visibly when logs are not actually exported.

## Validation

- `LOKI_TARGET=http://test-loki:3100 .venv/bin/python -m pytest tests/test_logs_exporter_static.py -q`
- `PIHOLE_URL=http://localhost:80 .venv/bin/python -m pytest -q`
- `git diff --check`
